### PR TITLE
set shared() to failable

### DIFF
--- a/GDPerformanceView-Swift/AppDelegate.swift
+++ b/GDPerformanceView-Swift/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if DEBUG
         if #available(iOS 13.0, *) {
         } else {
-            PerformanceMonitor.shared().start()
+            PerformanceMonitor.shared()?.start()
         }
         #endif
 
@@ -80,7 +80,7 @@ class SceneDelegate: UIResponder, UISceneDelegate {
     
     func sceneDidBecomeActive(_ scene: UIScene) {
         #if DEBUG
-        PerformanceMonitor.shared().start()
+        PerformanceMonitor.shared()?.start()
         #endif
     }
 }

--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceMonitor.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceMonitor.swift
@@ -99,9 +99,9 @@ public class PerformanceMonitor {
     
     // MARK: Private Properties
     
-    private static var sharedPerformanceMonitor: PerformanceMonitor!
+    private static var sharedPerformanceMonitor: PerformanceMonitor?
     
-    private lazy var performanceView = PerformanceView()
+    private var performanceView: PerformanceView
     private let performanceCalculator = PerformanceCalculator()
     private var state = States.paused
     
@@ -113,7 +113,10 @@ public class PerformanceMonitor {
     ///   - options: Display options. Allows to change the format of the displayed information.
     ///   - style: Style. Allows to change the appearance of the displayed information.
     ///   - delegate: Performance monitor output.
-    required public init(options: DisplayOptions = .default, style: Style = .dark, delegate: PerformanceMonitorDelegate? = nil) {
+    required public init?(options: DisplayOptions = .default, style: Style = .dark, delegate: PerformanceMonitorDelegate? = nil) {
+        guard let performanceView = PerformanceView.init(()) else { return nil }
+        
+        self.performanceView = performanceView
         self.performanceView.options = options
         self.performanceView.style = style
         
@@ -130,7 +133,7 @@ public class PerformanceMonitor {
     /// Initializes performance monitor singleton with default properties.
     ///
     /// - Returns: Performance monitor singleton.
-    public class func shared() -> PerformanceMonitor {
+    public class func shared() -> PerformanceMonitor? {
         if self.sharedPerformanceMonitor == nil {
             self.sharedPerformanceMonitor = PerformanceMonitor()
         }

--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceView.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceView.swift
@@ -75,16 +75,17 @@ internal class PerformanceView: UIWindow, PerformanceViewConfigurator {
     
     // MARK: Init Methods & Superclass Overriders
     
-    required internal init() {
+    // NOTE: fails if UIWindowScene was not connected.
+    internal convenience init?(_: Void) {
         if #available(iOS 13.0, *) {
-            let windowScene: UIWindowScene = UIApplication.shared
+            guard let windowScene: UIWindowScene = UIApplication.shared
                 .connectedScenes
                 .filter({ $0.activationState == .foregroundActive })
                 .compactMap({ $0 as? UIWindowScene })
-                .first!
-            super.init(windowScene: windowScene)
+                .first else { return nil }
+            self.init(windowScene: windowScene)
         } else {
-            super.init(frame: PerformanceView.windowFrame(withPrefferedHeight: Constants.prefferedHeight))
+            self.init(frame: PerformanceView.windowFrame(withPrefferedHeight: Constants.prefferedHeight))
         }
         
         self.configureWindow()
@@ -94,6 +95,15 @@ internal class PerformanceView: UIWindow, PerformanceViewConfigurator {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    
+    @available(iOS 13.0, *)
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
     }
     
     override func layoutSubviews() {


### PR DESCRIPTION
- from iOS13, new window initialization fails if windowScene was not
connected.